### PR TITLE
Loop 1: docs + doctor + safer hosted adapter errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,23 @@ pytest -q
 By default, `triage-assistant` uses the deterministic `dummy` adapter so the workshop can run
 without any external credentials.
 
+### Hosted adapter smoke-test (optional)
+
+**Goal:** Confirm a hosted provider can produce schema-valid JSON end-to-end.
+
+**Steps:**
+
+1. Configure a provider (GitHub Models or Microsoft Foundry).
+  - Keep secrets in environment variables or a local `.env` file (start from `.env.example`).
+  - Do not commit `.env` or paste tokens/keys into docs/issues.
+2. Run a minimal smoke test:
+
+```bash
+triage-assistant triage --adapter auto --title "Crash on startup" --body "Steps to reproduce: ..." --pretty
+```
+
+**Expected output:** A JSON response printed to stdout that validates against the schema (no stack trace).
+
 If you want to call a hosted model from the CLI, configure a provider and then run with
 `--adapter ...` (or set `TRIAGE_PROVIDER`).
 

--- a/docs/issues-draft.md
+++ b/docs/issues-draft.md
@@ -1,7 +1,239 @@
 # Issue drafts
 
-This file is generated during the workshop by running:
+Goal:
 
-- `/split-to-issues`
+- Convert `docs/plan.md` into copy/paste-ready GitHub Issue drafts.
 
-It contains issue draft text you can copy into GitHub Issues.
+Steps:
+
+1. Copy one issue draft into GitHub Issues.
+2. Create a branch from the issue.
+3. Implement → validate → open a PR.
+
+Expected outputs:
+
+- Each issue has a clear DoD and validation commands.
+- Deterministic gates stay green: `python3 -m pytest -q`.
+
+---
+
+## Issue 1: Workshop docs prerequisites + UI drift guardrails
+
+Labels (suggested):
+
+- `docs`
+- `p2`
+
+Problem statement:
+
+- Participants get blocked by version/UI differences (VS Code checkpoints, AI Toolkit preview UI).
+
+Definition of Done:
+
+- [ ] Add a short “Versions & prerequisites” note to the relevant workshop doc(s) under `docs/workshop/`.
+- [ ] Mention VS Code checkpoints requirement (VS Code 1.103+).
+- [ ] Mention AI Toolkit is preview and include at least one fallback navigation path (Command Palette / alternate menu).
+- [ ] Keep wording intent-based (avoid brittle click-by-click instructions).
+
+Validation command(s):
+
+- `python3 -m pytest -q`
+
+Notes / dependencies:
+
+- None.
+
+---
+
+## Issue 2: Add `triage-assistant doctor` for configuration diagnosis
+
+Labels (suggested):
+
+- `feature`
+- `p2`
+- `enhancement`
+
+Problem statement:
+
+- Hosted adapters fail when env vars are missing; diagnosing “what is auto doing?” is slow.
+
+Definition of Done:
+
+- [ ] Add a `doctor` command that prints which adapter `--adapter auto` would choose.
+- [ ] Show missing env vars for GitHub Models / Foundry / OpenAI-compatible (best-effort).
+- [ ] Do not break `triage` JSON-only stdout contract.
+- [ ] Add unit tests for the doctor output.
+
+Validation command(s):
+
+- `python3 -m pytest -q`
+
+Notes / dependencies:
+
+- None.
+
+---
+
+## Issue 3: Improve hosted adapter error messages (actionable, safe)
+
+Labels (suggested):
+
+- `bug`
+- `p1`
+
+Problem statement:
+
+- HTTP failures are not always actionable; users need “what to check next” without secrets leakage.
+
+Definition of Done:
+
+- [ ] Improve error messages for GitHub Models and Foundry adapters to include status code + safe hint.
+- [ ] Ensure tokens/keys are never printed.
+- [ ] Add at least one mocked failure test.
+
+Validation command(s):
+
+- `python3 -m pytest -q`
+
+Notes / dependencies:
+
+- Independent of Issue 2.
+
+---
+
+## Issue 4: Strengthen CLI contract tests (stdout JSON-only)
+
+Labels (suggested):
+
+- `bug`
+- `p1`
+
+Problem statement:
+
+- The most important contract is “`triage` prints JSON-only on stdout”. Regressions break pipelines.
+
+Definition of Done:
+
+- [ ] Add/extend tests that assert `triage` stdout is parseable JSON.
+- [ ] Add/extend tests that assert errors go to stderr (not stdout).
+
+Validation command(s):
+
+- `python3 -m pytest -q`
+
+Notes / dependencies:
+
+- This issue covers the deterministic baseline requirement: tests + schema + CLI stability.
+
+---
+
+## Issue 5: Improve `triage-assistant eval` Markdown report for fast iteration
+
+Labels (suggested):
+
+- `feature`
+- `p2`
+- `enhancement`
+
+Problem statement:
+
+- The local eval report is useful, but needs better “what failed” visibility for iteration.
+
+Definition of Done:
+
+- [ ] Improve report readability (expected vs predicted, rationale, failure examples).
+- [ ] Add a small “top failure patterns” section (basic grouping is OK).
+- [ ] Add a unit test that asserts key headings exist.
+
+Validation command(s):
+
+- `python3 -m pytest -q`
+
+Notes / dependencies:
+
+- None.
+
+---
+
+## Issue 6: Document the evaluation loop (AI Toolkit) + where to record results
+
+Labels (suggested):
+
+- `docs`
+- `p2`
+
+Problem statement:
+
+- Participants run evals but don’t consistently record findings in a reusable way.
+
+Definition of Done:
+
+- [ ] Add a short “Run/Evaluate” checklist under `docs/workshop/`.
+- [ ] Reference dataset: `datasets/triage_dataset.csv`.
+- [ ] Specify where to record results: `reports/eval/`.
+
+Validation command(s):
+
+- `python3 -m pytest -q`
+
+Notes / dependencies:
+
+- Issue 1 is recommended first (keeps docs consistent), but not required.
+- This issue covers the probabilistic evaluation requirement: AI Toolkit dataset run + versioning notes.
+
+---
+
+## Issue 7: Close the loop (eval findings → new issues)
+
+Labels (suggested):
+
+- `docs`
+- `p2`
+
+Problem statement:
+
+- Without turning failures into issues, the loop stalls.
+
+Definition of Done:
+
+- [ ] Document how to create issue drafts from evaluation findings.
+- [ ] (Optional) Document how to use `scripts/eval_report_to_issues.py` if appropriate.
+- [ ] Ensure the flow produces copy/pasteable issue drafts.
+
+Validation command(s):
+
+- `python3 -m pytest -q`
+
+Notes / dependencies:
+
+- Depends on Issue 6.
+- This issue covers the feedback loop closure requirement.
+
+---
+
+## Issue 8: Hosted adapter smoke-test note (optional but practical)
+
+Labels (suggested):
+
+- `docs`
+- `p2`
+
+Problem statement:
+
+- Participants want to confirm hosted adapters work end-to-end, but setup varies.
+
+Definition of Done:
+
+- [ ] Add a short doc note pointing to `docs/providers.md` and showing a minimal smoke-test command.
+- [ ] Include a reminder that secrets live in env vars / `.env` and should not be pasted.
+
+Validation command(s):
+
+- `python3 -m pytest -q`
+
+Notes / dependencies:
+
+- None.
+
+
+

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,7 +1,219 @@
-# Implementation plan (Workshop)
+# Implementation Plan
 
-In the workshop, you will generate and refine this plan using Copilot Chat and the prompt file:
-- `.github/prompts/02_create_plan.prompt.md`
+Goal:
 
-If you want to start from the template, see:
-- `docs/templates/plan.template.md`
+- Convert `docs/spec.md` into a workshop-sized backlog of issues (0.5–2h each) that are easy to validate.
+
+Steps:
+
+1. Pick one issue → create a branch → implement → open PR.
+2. Keep deterministic gates green: `python3 -m pytest -q`.
+3. Run probabilistic evaluation (AI Toolkit) periodically and record findings.
+
+Expected outputs:
+
+- 6–10 issue-sized tasks with clear DoD + validation.
+- Evaluation findings recorded under `reports/eval/`.
+
+## 1. Milestones
+
+- M0: Spec/plan/issues drafts exist (external memory)
+- M1: Deterministic contract stays green (tests + schema discipline)
+- M2: Hosted adapter smoke-tests (optional)
+- M3: Probabilistic evaluation loop (AI Toolkit dataset runs)
+- M4: Feedback closure (eval → new issues)
+
+## 2. Work breakdown
+
+Each task below is designed to be 0.5–2 hours.
+
+### Issue 1: Workshop docs prerequisites + UI drift guardrails
+
+Problem statement:
+
+- Participants get blocked by version/UI differences (VS Code checkpoints, AI Toolkit preview UI).
+
+Definition of Done:
+
+- [ ] Add a short “Versions & prerequisites” note to the relevant workshop doc(s) under `docs/workshop/`.
+- [ ] Mention VS Code checkpoints requirement (VS Code 1.103+).
+- [ ] Mention AI Toolkit is preview and include at least one fallback navigation path (Command Palette / alternate menu).
+
+Validation:
+
+- `python3 -m pytest -q`
+
+Dependencies:
+
+- None.
+
+### Issue 2: Add `triage-assistant doctor` for configuration diagnosis
+
+Problem statement:
+
+- Hosted adapters fail when env vars are missing; diagnosing “what is auto doing?” is slow.
+
+Definition of Done:
+
+- [ ] Add a `doctor` command that prints which adapter `--adapter auto` would choose.
+- [ ] Show missing env vars for GitHub Models / Foundry / OpenAI-compatible (best-effort).
+- [ ] Do not break `triage` JSON-only stdout contract.
+- [ ] Add unit tests for the doctor output.
+
+Validation:
+
+- `python3 -m pytest -q`
+
+Dependencies:
+
+- None.
+
+### Issue 3: Improve hosted adapter error messages (actionable, safe)
+
+Problem statement:
+
+- HTTP failures are not always actionable; users need “what to check next” without secrets leakage.
+
+Definition of Done:
+
+- [ ] Improve error messages for GitHub Models and Foundry adapters to include status code + safe hint.
+- [ ] Ensure tokens/keys are never printed.
+- [ ] Add at least one mocked failure test.
+
+Validation:
+
+- `python3 -m pytest -q`
+
+Dependencies:
+
+- None (can be done independently of Issue 2).
+
+### Issue 4: Strengthen CLI contract tests (stdout JSON-only)
+
+Problem statement:
+
+- The most important contract is “`triage` prints JSON-only on stdout”. Regressions break pipelines.
+
+Definition of Done:
+
+- [ ] Add/extend tests that assert `triage` stdout is parseable JSON.
+- [ ] Add/extend tests that assert errors go to stderr (not stdout).
+
+Validation:
+
+- `python3 -m pytest -q`
+
+Dependencies:
+
+- None.
+
+### Issue 5: Improve `triage-assistant eval` Markdown report for fast iteration
+
+Problem statement:
+
+- The local eval report is useful, but needs better “what failed” visibility for iteration.
+
+Definition of Done:
+
+- [ ] Improve report readability (expected vs predicted, rationale, failure examples).
+- [ ] Add a small “top failure patterns” section (even basic grouping is OK).
+- [ ] Add a unit test that asserts key headings exist.
+
+Validation:
+
+- `python3 -m pytest -q`
+
+Dependencies:
+
+- None.
+
+### Issue 6: Document the evaluation loop (AI Toolkit) + where to record results
+
+Problem statement:
+
+- Participants run evals but don’t consistently record findings in a reusable way.
+
+Definition of Done:
+
+- [ ] Add a short “Run/Evaluate” checklist under `docs/workshop/`.
+- [ ] Reference dataset: `datasets/triage_dataset.csv`.
+- [ ] Specify where to record results: `reports/eval/`.
+
+Validation:
+
+- `python3 -m pytest -q`
+
+Dependencies:
+
+- Issue 1 recommended first (to keep docs consistent), but not required.
+
+### Issue 7: Close the loop (eval findings → new issues)
+
+Problem statement:
+
+- Without turning failures into issues, the loop stalls.
+
+Definition of Done:
+
+- [ ] Document how to create issue drafts from evaluation findings.
+- [ ] (Optional) Document how to use `scripts/eval_report_to_issues.py` if appropriate.
+- [ ] Ensure the flow produces copy/pasteable issue drafts.
+
+Validation:
+
+- `python3 -m pytest -q`
+
+Dependencies:
+
+- Depends on Issue 6 (evaluation loop docs) for best readability.
+
+### Issue 8: Hosted adapter smoke-test note (optional but practical)
+
+Problem statement:
+
+- Workshop participants often want to confirm hosted adapters work end-to-end, but setup varies.
+
+Definition of Done:
+
+- [ ] Add a short doc note pointing to `docs/providers.md` and showing a minimal smoke-test command.
+- [ ] Include a reminder that secrets live in env vars / `.env` and should not be pasted.
+
+Validation:
+
+- `python3 -m pytest -q`
+
+Dependencies:
+
+- None.
+
+## 3. Testing strategy
+
+- Unit tests: `python3 -m pytest -q`
+- CLI contract tests: stdout JSON-only for `triage`, errors on stderr
+- Schema/contract tests: validate output against `TriageOutput` (`src/triage_assistant/schema.py`)
+
+## 4. Evaluation strategy
+
+- AI Toolkit:
+  - dataset: `datasets/triage_dataset.csv`
+  - baseline version + compare against later iterations
+  - metrics: type accuracy, priority accuracy, label overlap/F1
+- Local smoke eval:
+  - `triage-assistant eval --adapter dummy --dataset datasets/triage_dataset.csv`
+- Record outcomes in `reports/eval/`
+
+## 5. Risks and mitigations
+
+- Provider auth/rate limits: keep dummy baseline; treat hosted runs as best-effort.
+- JSON mode differences across models: always validate against schema; keep extraction robust.
+- UI drift (preview tooling): document intent + fallbacks, not fragile click paths.
+
+## 6. Timebox
+
+Good enough for one workshop session:
+
+- complete 1–2 issues with tests
+- run at least one evaluation (AI Toolkit or local eval)
+- record findings under `reports/eval/`
+
+

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,9 +1,147 @@
 # Spec: Issue Triage Assistant (Workshop)
 
-This file is intentionally minimal at repository creation time.
+## Goal
 
-In the workshop, you will generate and refine this spec using Copilot Chat and the prompt file:
-- `.github/prompts/01_draft_spec.prompt.md`
+Build a small CLI tool that turns a GitHub Issue (title + body) into a **stable, schema-valid JSON** triage result.
+This repository is a workshop artifact to practice an agentic inner loop:
 
-If you want to start from the template, see:
-- `docs/templates/spec.template.md`
+- Spec → Plan → Issues → Implement → Run/Evaluate → Feedback → repeat
+
+## How you use it (high level)
+
+Steps:
+
+1. Run `triage-assistant triage --title ... --body ...` to get triage JSON.
+2. Iterate on prompts/agents with AI Toolkit (probabilistic loop).
+3. Keep deterministic checks green with `pytest -q`.
+
+Expected outputs:
+
+- `triage-assistant triage ...` prints **a single JSON object** to stdout.
+- Errors are printed to stderr.
+- JSON validates against `src/triage_assistant/schema.py`.
+
+## 1. Problem statement
+
+Maintainers (and workshop participants) spend time repeatedly classifying issues.
+We want a fast, consistent triage output that is easy to:
+
+- automate (JSON)
+- test (schema + unit tests)
+- evaluate (dataset + reports)
+
+## 2. Goals
+
+- Provide a CLI that triages issues into `type`, `priority`, `labels`, and `rationale`.
+- Enforce a stable JSON output contract via `src/triage_assistant/schema.py`.
+- Support both:
+	- **offline** deterministic baseline (for repeatable tests)
+	- **hosted-model** adapters (for realism and iteration)
+- Enable prompt/agent iteration with evaluation using `datasets/triage_dataset.csv`.
+
+## 3. Non-goals
+
+- No GitHub API automation (no label writing back to GitHub).
+- No web UI.
+- No attempt to be “perfect triage”; the goal is a reliable loop for improvement.
+- No secret management beyond environment variables (never commit secrets).
+
+## 4. Users and use cases
+
+- Maintainers: quickly classify new issues into buckets.
+- Contributors: use the output to pick the next task (what matters most).
+- Workshop participants: practice prompt/agent iteration with measurable feedback.
+
+## 5. Functional requirements
+
+- CLI command `triage-assistant triage --title ... --body ...` prints schema-valid JSON to stdout.
+- CLI command `triage-assistant schema` prints JSON schema.
+- CLI command `triage-assistant eval --dataset ... --adapter ...` runs a local, lightweight evaluation.
+- Adapter selection:
+	- explicit: `--adapter dummy|github|foundry|openai|auto`
+	- implicit: `TRIAGE_PROVIDER` when using `--adapter auto`
+- Output discipline:
+	- JSON-only on stdout for `triage`
+	- human-readable errors on stderr
+- A deterministic baseline adapter exists (`DummyAdapter`).
+- Hosted adapters validate model output against `TriageOutput`.
+
+## 6. Output contract
+
+The output must be a single JSON object with:
+
+- `type`: `bug | feature | docs | question`
+- `priority`: `p0 | p1 | p2`
+- `labels`: string array
+- `rationale`: short string
+
+### Label taxonomy (used in this repo)
+
+The workshop uses a small, stable label taxonomy so results are measurable and easy to reason about.
+
+Required labels:
+
+- Type label: one of `bug`, `feature`, `docs`, `question` (must match `type`)
+- Priority label: one of `p0`, `p1`, `p2` (must match `priority`)
+
+Optional labels (allowed, not always present):
+
+- `needs-repro`: bug report missing clear reproduction steps
+- `needs-env-info`: bug report missing environment/version info
+- `needs-info`: question/issue is too vague (often short questions)
+- `good-first-issue`: small docs fixes (typos, spelling, grammar)
+- `enhancement`: non-urgent feature requests
+- `security`: security-related bug reports (vulnerabilities, data loss, RCE signals, etc.)
+
+Notes:
+
+- Labels are normalized for stability (trim, remove empties, de-duplicate case-insensitively) by `TriageOutput`.
+- Adapters may propose additional labels, but workshop evaluation should focus on the taxonomy above.
+
+Source of truth:
+
+- `src/triage_assistant/schema.py` (`TriageOutput`)
+
+## 7. Acceptance criteria
+
+All criteria must be testable with concrete commands.
+
+- Unit tests pass:
+	- `python3 -m pytest -q`
+- The `triage` command prints schema-valid JSON to stdout:
+	- `triage-assistant triage --adapter dummy --title "Crash when saving" --body "Steps to reproduce:\n1. Open\n2. Save\nVersion: 1.0" --pretty`
+	- (optional strict check) pipe the JSON into the schema validator:
+		- `triage-assistant triage --adapter dummy --title "Crash" --body "..." | python3 -c "from triage_assistant.schema import validate_output_json; import sys; validate_output_json(sys.stdin.read())"`
+- The `schema` command prints valid JSON:
+	- `triage-assistant schema | python3 -c "import json,sys; json.loads(sys.stdin.read())"`
+- For hosted adapters, missing env vars produce a clear CLI error on stderr and exit code != 0.
+
+## 8. Evaluation plan
+
+Deterministic gates:
+
+- unit tests (`pytest -q`)
+- schema validation (adapters return `TriageOutput`)
+
+Probabilistic gates:
+
+- AI Toolkit bulk runs using `datasets/triage_dataset.csv`
+- record findings under `reports/eval/`
+
+Expected outputs:
+
+- A short report that highlights where the model failed (taxonomy mismatch, wrong priority, unstable labels, etc.).
+
+## 9. Risks and mitigations
+
+- Model output is not valid JSON → enforce JSON extraction + schema validation.
+- Rate limits / transient API failures → keep an offline baseline; treat hosted runs as best-effort.
+- Secret leakage → keep secrets in environment variables; never paste tokens into issues/chat.
+- UI drift (preview tooling) → document intent + fallback navigation rather than brittle click paths.
+
+## 10. Open questions
+
+- What counts as a “good enough” evaluation improvement within the workshop timebox?
+
+
+

--- a/docs/workshop/01_setup.md
+++ b/docs/workshop/01_setup.md
@@ -9,6 +9,23 @@ Get your VS Code workspace into a state where you can run the full loop:
 - GitHub Issues (create issues, start work on issues)
 - Python environment (run tests and CLI)
 
+## Versions & prerequisites
+
+- **VS Code 1.103+**
+   - Some workshop features (for example, chat checkpoints) are newest in recent VS Code releases.
+   - If anything in this workshop looks “missing”, first confirm your VS Code version.
+- **Extensions** (installed and enabled in this workspace)
+   - GitHub Copilot + GitHub Copilot Chat
+   - AI Toolkit for VS Code
+   - GitHub Pull Requests and Issues
+   - Python + Pylance
+- **UI drift is normal**
+   - AI Toolkit is in **preview** and feature names/locations can change between releases.
+   - When the docs say “open X”, treat it as intent: use **Command Palette** (`Ctrl/Cmd+Shift+P`) and search for the feature name (for example: “AI Toolkit”, “Model Catalog”, “Evaluation”).
+- **Checkpoints are optional**
+   - If you can't find or enable chat checkpoints, continue anyway.
+   - Use `git` commits/branches as your “rewind” mechanism.
+
 ## Setup Options
 
 You can set up this workshop in two ways:
@@ -228,3 +245,4 @@ pytest -q
 Regardless of which setup option you chose, you're now ready to start the workshop!
 
 Next: `02_spec.md`
+

--- a/docs/workshop/06_run_and_evaluate.md
+++ b/docs/workshop/06_run_and_evaluate.md
@@ -11,6 +11,24 @@ The workshop aims to make you feel the difference between:
 - “the code works”
 - “the model is getting better”
 
+## Run/Evaluate checklist
+
+Use this as a quick, reproducible checklist before you move on.
+
+- [ ] Run deterministic gates:
+	- [ ] `pytest -q`
+	- [ ] (optional) `ruff check .`
+	- [ ] (optional) `ruff format --check .`
+- [ ] Run a dataset evaluation:
+	- [ ] Use the workshop dataset: `datasets/triage_dataset.csv`
+	- [ ] Run either:
+		- [ ] AI Toolkit bulk run + evaluation (preferred for iteration)
+		- [ ] local eval: `triage-assistant eval --adapter dummy --dataset datasets/triage_dataset.csv`
+- [ ] Record findings in this repo (don’t leave them only in the UI):
+	- [ ] Create a Markdown report under `reports/eval/`
+	- [ ] Start from `docs/templates/eval-report.template.md`
+	- [ ] Note what changed, what improved/regressed, and 3 concrete failure cases
+
 ## Lane A: Deterministic gates
 
 Run:
@@ -27,6 +45,14 @@ ruff format --check .
 ```
 
 ## Lane B: Probabilistic evaluation with AI Toolkit
+
+> AI Toolkit is in **preview**, so the exact UI and feature names can drift across VS Code / extension versions.
+>
+> If you can’t find a panel or button mentioned below, use the **Command Palette** (`Ctrl/Cmd+Shift+P`) and search for:
+> “AI Toolkit”, “Model Catalog”, “Bulk Run”, or “Evaluation”.
+>
+> The intent of this lane is stable:
+> 1) pick a model/provider, 2) run your prompt/agent on a dataset, 3) evaluate, 4) save a version you can compare.
 
 ### Step 1 — Open AI Toolkit
 
@@ -97,3 +123,4 @@ At minimum record:
 - At least one baseline evaluation in AI Toolkit (v1)
 
 Next: `07_feedback.md`
+

--- a/docs/workshop/07_feedback.md
+++ b/docs/workshop/07_feedback.md
@@ -23,6 +23,17 @@ Pick 1–3 actions that are:
 
 Use the issue templates.
 
+To keep the loop repeatable, start from the **Actions** section of your evaluation report.
+If you used `docs/templates/eval-report.template.md`, your report already has:
+
+- `## 4. Actions`
+
+Under that header, write each action as a bullet point. Keep actions small (0.5–2 hours).
+Example:
+
+- Fix label normalization edge-cases (dedupe case-insensitively)
+- Add a regression test for stdout JSON-only on `triage`
+
 For each new issue:
 - include a DoD
 - include how to validate (AI Toolkit version compare OR unit tests)
@@ -30,6 +41,28 @@ For each new issue:
 If failures are due to unclear requirements, update:
 - `docs/spec.md`
 - `docs/plan.md`
+
+#### Optional: generate copy/pasteable issue drafts from the eval report
+
+If you want a faster path from “Actions” to “Issues”, use the helper script:
+
+- `scripts/eval_report_to_issues.py`
+
+It extracts bullet points under `## 4. Actions` and generates Markdown issue skeletons you can copy/paste into GitHub.
+
+Steps:
+
+1. Ensure your evaluation report has a `## 4. Actions` section with bullet points.
+2. Run the script and write drafts to a Markdown file you can keep in the repo.
+
+Suggested output locations (pick one convention and stick to it):
+
+- `reports/eval/issues-from-eval.md` (keeps “findings → tasks” together)
+- `docs/issues-from-eval.md` (keeps drafts near other workshop docs)
+
+Expected output:
+
+- A Markdown file containing “Draft 1…N” sections with Problem/DoD/Validation headings, ready to copy/paste into GitHub Issues.
 
 ### Step 3 — Implement one feedback issue
 
@@ -53,3 +86,4 @@ Append or create a new evaluation note under `reports/eval/`.
 - Written record of what improved and why
 
 Next: `08_retro.md`
+

--- a/reports/eval/README.md
+++ b/reports/eval/README.md
@@ -16,3 +16,21 @@ Suggested naming:
 Template:
 
 - See `docs/templates/eval-report.template.md`
+
+## Turn findings into issues (close the loop)
+
+To keep the workshop loop moving, convert your evaluation report into actionable tasks:
+
+1. In your report, write 3–10 bullets under `## 4. Actions`.
+2. Convert those actions into GitHub Issues with a clear DoD + validation.
+
+Optional helper:
+
+- `scripts/eval_report_to_issues.py` can generate copy/pasteable issue draft skeletons from the bullets under `## 4. Actions`.
+
+Suggested place to save generated drafts:
+
+- `reports/eval/issues-from-eval.md`
+
+See also: `docs/workshop/07_feedback.md`.
+

--- a/src/triage_assistant/cli.py
+++ b/src/triage_assistant/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Annotated
 
@@ -77,6 +78,73 @@ def _resolve_adapter(adapter_name: str | None):
     raise typer.BadParameter(f"Unknown adapter: {adapter_name}")
 
 
+def _is_set(name: str) -> bool:
+    return bool((os.getenv(name) or "").strip())
+
+
+def _missing_env_for_github_models() -> list[str]:
+    # GitHub Models accepts TRIAGE_GITHUB_TOKEN or (fallback) GITHUB_TOKEN.
+    if _is_set("TRIAGE_GITHUB_TOKEN") or _is_set("GITHUB_TOKEN"):
+        return []
+    return ["TRIAGE_GITHUB_TOKEN (or GITHUB_TOKEN)"]
+
+
+def _missing_env_for_foundry() -> list[str]:
+    missing: list[str] = []
+    if not _is_set("TRIAGE_FOUNDRY_ENDPOINT"):
+        missing.append("TRIAGE_FOUNDRY_ENDPOINT")
+
+    if not (_is_set("TRIAGE_FOUNDRY_API_KEY") or _is_set("AZURE_INFERENCE_CREDENTIAL")):
+        missing.append("TRIAGE_FOUNDRY_API_KEY (or AZURE_INFERENCE_CREDENTIAL)")
+
+    if not _is_set("TRIAGE_FOUNDRY_MODEL"):
+        missing.append("TRIAGE_FOUNDRY_MODEL")
+    return missing
+
+
+def _missing_env_for_openai_compatible() -> list[str]:
+    missing: list[str] = []
+    if not _is_set("TRIAGE_OPENAI_BASE_URL"):
+        missing.append("TRIAGE_OPENAI_BASE_URL")
+    if not _is_set("TRIAGE_OPENAI_API_KEY"):
+        missing.append("TRIAGE_OPENAI_API_KEY")
+    if not _is_set("TRIAGE_OPENAI_MODEL"):
+        missing.append("TRIAGE_OPENAI_MODEL")
+    return missing
+
+
+def _auto_adapter_choice() -> tuple[str, str]:
+    """Return (adapter_name, reason) for what `--adapter auto` would choose.
+
+    This mirrors the intent of `triage_assistant.triage.get_default_adapter()` but does
+    not instantiate adapters or make network calls.
+    """
+
+    provider = (os.getenv("TRIAGE_PROVIDER") or "").strip()
+    if provider:
+        normalized = provider.lower().replace("_", "-")
+        if normalized in {"github", "github-models"}:
+            return "github", f"TRIAGE_PROVIDER={provider}"
+        if normalized in {"foundry", "azure-foundry", "ai-foundry"}:
+            return "foundry", f"TRIAGE_PROVIDER={provider}"
+        if normalized in {"openai", "openai-compatible"}:
+            return "openai", f"TRIAGE_PROVIDER={provider}"
+        if normalized in {"dummy", "offline"}:
+            return "dummy", f"TRIAGE_PROVIDER={provider}"
+        return "(invalid)", f"TRIAGE_PROVIDER={provider} (unsupported)"
+
+    if not _missing_env_for_github_models():
+        return "github", "GitHub Models credentials detected"
+
+    if not _missing_env_for_foundry():
+        return "foundry", "Foundry credentials detected"
+
+    if not _missing_env_for_openai_compatible():
+        return "openai", "OpenAI-compatible configuration detected"
+
+    return "dummy", "No hosted adapter credentials detected"
+
+
 @app.command()
 def triage(
     title: Annotated[str, typer.Option(help="GitHub Issue title.")],
@@ -122,6 +190,48 @@ def schema(pretty: Annotated[bool, typer.Option(help="Pretty-print JSON schema."
 
 
 @app.command()
+def doctor() -> None:
+    """Diagnose configuration and explain what `--adapter auto` would do.
+
+    This command is intentionally best-effort and never prints secret values.
+    """
+
+    chosen, reason = _auto_adapter_choice()
+    provider = (os.getenv("TRIAGE_PROVIDER") or "").strip() or None
+
+    gh_missing = _missing_env_for_github_models()
+    foundry_missing = _missing_env_for_foundry()
+    openai_missing = _missing_env_for_openai_compatible()
+
+    lines: list[str] = []
+    lines.append("triage-assistant doctor")
+    lines.append("")
+    lines.append("Auto adapter resolution")
+    lines.append(f"- TRIAGE_PROVIDER: {provider if provider is not None else '(not set)'}")
+    lines.append(f"- Selected adapter: {chosen} ({reason})")
+
+    if chosen == "(invalid)":
+        lines.append("")
+        lines.append(
+            "NOTE: TRIAGE_PROVIDER is set to an unsupported value. `--adapter auto` will fail."
+        )
+
+    lines.append("")
+    lines.append("Environment checks (missing only)")
+
+    def _fmt_missing(provider_name: str, missing: list[str]) -> str:
+        if not missing:
+            return f"- {provider_name}: OK"
+        return f"- {provider_name}: missing {', '.join(missing)}"
+
+    lines.append(_fmt_missing("GitHub Models", gh_missing))
+    lines.append(_fmt_missing("Foundry", foundry_missing))
+    lines.append(_fmt_missing("OpenAI-compatible", openai_missing))
+
+    typer.echo("\n".join(lines))
+
+
+@app.command()
 def eval(
     dataset: Annotated[Path, typer.Option(help="Path to the CSV dataset.")] = Path(
         "datasets/triage_dataset.csv"
@@ -137,9 +247,7 @@ def eval(
     ] = "dummy",
     report: Annotated[
         Path | None,
-        typer.Option(
-            help="Write a Markdown report to this path. If omitted, print summary only."
-        ),
+        typer.Option(help="Write a Markdown report to this path. If omitted, print summary only."),
     ] = None,
 ) -> None:
     """Run a simple local evaluation against the dataset.
@@ -248,6 +356,25 @@ def _render_report(
     metrics: dict[str, float],
     results: list[tuple[dict[str, str], TriageOutput]],
 ) -> str:
+    def _parse_expected_labels(s: str) -> set[str]:
+        s = (s or "").strip()
+        if not s:
+            return set()
+        try:
+            raw = json.loads(s)
+            if isinstance(raw, list):
+                return {str(x).strip() for x in raw if str(x).strip()}
+        except Exception:
+            # tolerate "a,b,c" format
+            return {x.strip() for x in s.split(",") if x.strip()}
+        return set()
+
+    def _safe_excerpt(text: str, *, max_chars: int = 240) -> str:
+        text = (text or "").strip().replace("\r\n", "\n")
+        if len(text) <= max_chars:
+            return text
+        return text[: max_chars - 1].rstrip() + "…"
+
     lines: list[str] = []
     lines.append("# Local Evaluation Report")
     lines.append("")
@@ -260,28 +387,149 @@ def _render_report(
     lines.append(f"- Priority accuracy: {metrics['priority_accuracy']:.3f}")
     lines.append(f"- Label F1: {metrics['label_f1']:.3f}")
     lines.append("")
-    lines.append("## Example failures (first 5)")
+
+    # Failure pattern analysis (basic grouping is OK; keep deterministic ordering).
+    type_confusions: dict[tuple[str, str], int] = {}
+    priority_confusions: dict[tuple[str, str], int] = {}
+    missing_label_counts: dict[str, int] = {}
+    extra_label_counts: dict[str, int] = {}
+    mismatch_kind_counts: dict[str, int] = {}
+
+    total_failures = 0
+    for row, pred in results:
+        exp_type = (row.get("expected_type", "") or "").strip()
+        exp_pri = (row.get("expected_priority", "") or "").strip()
+        exp_labels = _parse_expected_labels(row.get("expected_labels", ""))
+        pred_labels = {x.strip() for x in pred.labels if x.strip()}
+
+        type_mismatch = pred.type.value != exp_type
+        pri_mismatch = pred.priority.value != exp_pri
+        label_mismatch = exp_labels != pred_labels
+
+        if not (type_mismatch or pri_mismatch or label_mismatch):
+            continue
+
+        total_failures += 1
+
+        mismatch_kinds: list[str] = []
+        if type_mismatch:
+            mismatch_kinds.append("type")
+            key = (exp_type, pred.type.value)
+            type_confusions[key] = type_confusions.get(key, 0) + 1
+        if pri_mismatch:
+            mismatch_kinds.append("priority")
+            key = (exp_pri, pred.priority.value)
+            priority_confusions[key] = priority_confusions.get(key, 0) + 1
+        if label_mismatch:
+            mismatch_kinds.append("labels")
+            for missing in sorted(exp_labels - pred_labels):
+                missing_label_counts[missing] = missing_label_counts.get(missing, 0) + 1
+            for extra in sorted(pred_labels - exp_labels):
+                extra_label_counts[extra] = extra_label_counts.get(extra, 0) + 1
+
+        kind = "+".join(mismatch_kinds)
+        mismatch_kind_counts[kind] = mismatch_kind_counts.get(kind, 0) + 1
+
+    lines.append("## Top failure patterns")
+    lines.append("")
+    lines.append(f"- Failures: {total_failures} / {int(metrics['n'])}")
+
+    if total_failures == 0:
+        lines.append("")
+        lines.append("No failures found.")
+        lines.append("")
+        return "\n".join(lines)
+
+    def _top_items(d: dict[object, int], *, limit: int = 5):
+        return sorted(d.items(), key=lambda kv: (-kv[1], str(kv[0])))[:limit]
+
+    lines.append("")
+    lines.append("Mismatch breakdown (by fields)")
+    for kind, count in _top_items(mismatch_kind_counts, limit=10):
+        lines.append(f"- {kind}: {count}")
+
+    top_type = _top_items(type_confusions)
+    if top_type:
+        lines.append("")
+        lines.append("Most common type confusions")
+        for (exp, got), count in top_type:
+            lines.append(f"- `{exp} → {got}`: {count}")
+
+    top_pri = _top_items(priority_confusions)
+    if top_pri:
+        lines.append("")
+        lines.append("Most common priority confusions")
+        for (exp, got), count in top_pri:
+            lines.append(f"- `{exp} → {got}`: {count}")
+
+    top_missing = _top_items(missing_label_counts)
+    if top_missing:
+        lines.append("")
+        lines.append("Most commonly missed labels")
+        for label, count in top_missing:
+            lines.append(f"- `{label}`: {count}")
+
+    top_extra = _top_items(extra_label_counts)
+    if top_extra:
+        lines.append("")
+        lines.append("Most common extra labels")
+        for label, count in top_extra:
+            lines.append(f"- `{label}`: {count}")
+
+    lines.append("")
+    lines.append("## Failure examples (first 5)")
     lines.append("")
     count = 0
     for row, pred in results:
-        exp_type = row.get("expected_type", "")
-        exp_pri = row.get("expected_priority", "")
-        if pred.type.value == exp_type and pred.priority.value == exp_pri:
+        exp_type = (row.get("expected_type", "") or "").strip()
+        exp_pri = (row.get("expected_priority", "") or "").strip()
+        exp_labels = _parse_expected_labels(row.get("expected_labels", ""))
+        pred_labels = {x.strip() for x in pred.labels if x.strip()}
+
+        if (
+            pred.type.value == exp_type
+            and pred.priority.value == exp_pri
+            and pred_labels == exp_labels
+        ):
             continue
-        lines.append(f"### {row.get('id', '(no id)')}: {row.get('title', '').strip()}")
+
+        title = (row.get("title", "") or "").strip()
+        issue_id = (row.get("id", "") or "").strip() or "(no id)"
+        body_excerpt = _safe_excerpt(row.get("body", ""))
+
+        lines.append(f"### {issue_id}: {title}")
         lines.append("")
-        lines.append(
-            f"- Expected: type={exp_type}, priority={exp_pri}, labels={row.get('expected_labels', '')}"
-        )
-        lines.append(
-            f"- Predicted: type={pred.type.value}, priority={pred.priority.value}, labels={pred.labels}"
-        )
-        lines.append(f"- Rationale: {pred.rationale}")
+
+        if body_excerpt:
+            lines.append("**Input (excerpt)**")
+            lines.append("")
+            lines.append("```text")
+            lines.append(body_excerpt)
+            lines.append("```")
+            lines.append("")
+
+        lines.append("**Expected**")
+        lines.append("")
+        lines.append(f"- type: `{exp_type}`")
+        lines.append(f"- priority: `{exp_pri}`")
+        lines.append(f"- labels: `{sorted(exp_labels)}`")
+        lines.append("")
+
+        lines.append("**Predicted**")
+        lines.append("")
+        lines.append(f"- type: `{pred.type.value}`")
+        lines.append(f"- priority: `{pred.priority.value}`")
+        lines.append(f"- labels: `{sorted(pred_labels)}`")
+
+        missing = sorted(exp_labels - pred_labels)
+        extra = sorted(pred_labels - exp_labels)
+        if missing:
+            lines.append(f"- missing labels: `{missing}`")
+        if extra:
+            lines.append(f"- extra labels: `{extra}`")
+        lines.append(f"- rationale: {pred.rationale}")
         lines.append("")
         count += 1
         if count >= 5:
             break
-    if count == 0:
-        lines.append("No failures found.")
-        lines.append("")
     return "\n".join(lines)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,8 @@
 import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 from typer.testing import CliRunner
 
@@ -25,8 +29,189 @@ def test_cli_triage_outputs_valid_json() -> None:
     validate_output_json(result.stdout.strip())
 
 
+def test_cli_triage_stdout_is_json_object_only() -> None:
+    """The triage command must emit a single JSON object to stdout (no logs)."""
+
+    result = runner.invoke(
+        app,
+        [
+            "triage",
+            "--title",
+            "Crash when saving file",
+            "--body",
+            "Steps to reproduce:\n1. Open\n2. Save\nVersion: 1.0",
+            "--adapter",
+            "dummy",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    # Strict-ish contract: parse stdout as JSON and ensure it is an object.
+    parsed = json.loads(result.stdout)
+    assert isinstance(parsed, dict)
+
+
 def test_cli_schema_outputs_json_schema() -> None:
     result = runner.invoke(app, ["schema"])
     assert result.exit_code == 0
     data = json.loads(result.stdout)
     assert data.get("type") == "object"
+
+
+def _blank_env() -> dict[str, str]:
+    # Ensure tests do not depend on the caller's environment.
+    return {
+        "TRIAGE_PROVIDER": "",
+        "TRIAGE_GITHUB_TOKEN": "",
+        "GITHUB_TOKEN": "",
+        "TRIAGE_FOUNDRY_ENDPOINT": "",
+        "TRIAGE_FOUNDRY_API_KEY": "",
+        "AZURE_INFERENCE_CREDENTIAL": "",
+        "TRIAGE_FOUNDRY_MODEL": "",
+        "TRIAGE_OPENAI_BASE_URL": "",
+        "TRIAGE_OPENAI_API_KEY": "",
+        "TRIAGE_OPENAI_MODEL": "",
+    }
+
+
+def test_cli_doctor_defaults_to_dummy_when_no_env() -> None:
+    result = runner.invoke(app, ["doctor"], env=_blank_env())
+    assert result.exit_code == 0
+    assert "Selected adapter: dummy" in result.stdout
+    assert "GitHub Models: missing TRIAGE_GITHUB_TOKEN (or GITHUB_TOKEN)" in result.stdout
+    assert "Foundry: missing TRIAGE_FOUNDRY_ENDPOINT" in result.stdout
+    assert "OpenAI-compatible: missing TRIAGE_OPENAI_BASE_URL" in result.stdout
+
+
+def test_cli_doctor_provider_forces_selection_even_if_missing() -> None:
+    env = _blank_env() | {"TRIAGE_PROVIDER": "github"}
+    result = runner.invoke(app, ["doctor"], env=env)
+    assert result.exit_code == 0
+    assert "Selected adapter: github (TRIAGE_PROVIDER=github)" in result.stdout
+    assert "GitHub Models: missing TRIAGE_GITHUB_TOKEN (or GITHUB_TOKEN)" in result.stdout
+
+
+def test_cli_doctor_selects_github_when_token_present() -> None:
+    env = _blank_env() | {"TRIAGE_GITHUB_TOKEN": "not-a-real-token"}
+    result = runner.invoke(app, ["doctor"], env=env)
+    assert result.exit_code == 0
+    assert "Selected adapter: github" in result.stdout
+    assert "GitHub Models: OK" in result.stdout
+
+
+def _run_cli_subprocess(
+    args: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the Typer app in a subprocess so stdout/stderr are captured separately."""
+
+    code = (
+        "import sys; "
+        "from triage_assistant.cli import app; "
+        "sys.argv = ['triage-assistant'] + sys.argv[1:]; "
+        "app()"
+    )
+
+    proc_env = os.environ.copy()
+    if env is not None:
+        proc_env.update(env)
+
+    return subprocess.run(
+        [sys.executable, "-c", code, *args],
+        env=proc_env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_cli_triage_success_stdout_only_subprocess() -> None:
+    """Enforce the strict contract: JSON on stdout, nothing on stderr."""
+
+    proc = _run_cli_subprocess(
+        [
+            "triage",
+            "--title",
+            "Crash when saving file",
+            "--body",
+            "Steps to reproduce:\n1. Open\n2. Save\nVersion: 1.0",
+            "--adapter",
+            "dummy",
+        ],
+        env=_blank_env(),
+    )
+
+    assert proc.returncode == 0
+    assert proc.stderr.strip() == ""
+    validate_output_json(proc.stdout.strip())
+
+
+def test_cli_triage_missing_env_var_error_goes_to_stderr_only_subprocess() -> None:
+    """Configuration errors must not pollute stdout (JSON contract)."""
+
+    proc = _run_cli_subprocess(
+        [
+            "triage",
+            "--title",
+            "Crash on startup",
+            "--body",
+            "Steps: 1. Install 2. Launch",
+            "--adapter",
+            "github",
+        ],
+        env=_blank_env(),
+    )
+
+    assert proc.returncode != 0
+    assert proc.stdout.strip() == ""
+    assert "Missing environment variable" in proc.stderr
+    assert "TRIAGE_GITHUB_TOKEN" in proc.stderr
+
+
+def test_cli_triage_body_file_read_error_goes_to_stderr_only_subprocess(
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "does_not_exist.txt"
+    proc = _run_cli_subprocess(
+        [
+            "triage",
+            "--title",
+            "Crash on startup",
+            "--body-file",
+            str(missing),
+            "--adapter",
+            "dummy",
+        ],
+        env=_blank_env(),
+    )
+
+    assert proc.returncode != 0
+    assert proc.stdout.strip() == ""
+    assert "Failed to read body file" in proc.stderr
+
+
+def test_cli_eval_report_contains_key_headings(tmp_path: Path) -> None:
+    dataset = Path(__file__).resolve().parents[1] / "datasets" / "triage_dataset.csv"
+    report_path = tmp_path / "eval_report.md"
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "--adapter",
+            "dummy",
+            "--dataset",
+            str(dataset),
+            "--report",
+            str(report_path),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert report_path.exists()
+
+    report = report_path.read_text(encoding="utf-8")
+    assert "# Local Evaluation Report" in report
+    assert "## Metrics" in report
+    assert "## Top failure patterns" in report
+    assert "## Failure examples (first 5)" in report

--- a/tests/test_hosted_adapter_errors.py
+++ b/tests/test_hosted_adapter_errors.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from triage_assistant.adapters.chat_completions import ChatCompletionsError
+from triage_assistant.adapters.github_models import GitHubModelsAdapter
+
+
+def test_github_models_http_401_error_is_actionable_and_does_not_leak_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = "ghp_SUPER_SECRET_TOKEN"
+
+    adapter = GitHubModelsAdapter(token=token)
+
+    request = httpx.Request(
+        "POST",
+        "https://models.github.ai/inference/chat/completions",
+    )
+    response = httpx.Response(401, request=request, json={"error": "unauthorized"})
+
+    class FakeClient:
+        def __init__(self, *, timeout: float) -> None:  # noqa: ARG002
+            pass
+
+        def __enter__(self) -> FakeClient:
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+            return None
+
+        def post(self, url: str, *, headers: dict[str, str], json: dict) -> httpx.Response:  # noqa: ANN001
+            return response
+
+    monkeypatch.setattr("triage_assistant.adapters.github_models.httpx.Client", FakeClient)
+
+    with pytest.raises(ChatCompletionsError) as excinfo:
+        adapter.triage(title="Crash on startup", body="Steps: 1. Run 2. Crash")
+
+    msg = str(excinfo.value)
+    assert "GitHub Models" in msg
+    assert "HTTP 401" in msg
+    assert "TRIAGE_GITHUB_TOKEN" in msg
+
+    # Ensure secrets are not echoed.
+    assert token not in msg
+    assert "Bearer" not in msg


### PR DESCRIPTION
## Summary
This PR lands the “loop 1” workshop improvements from `scenario/loop1-run-prompts` into `main`.

Key outcomes:
- Adds a **hosted adapter smoke-test** note to the README (optional but practical).
- Adds a `triage-assistant doctor` command for **configuration diagnosis** (without leaking secrets).
- Improves hosted adapter error messages to be more **actionable and secret-safe**.
- Improves local `triage-assistant eval` Markdown report (failure patterns + examples).
- Updates workshop docs to include **version/prereq guardrails** and evaluation/feedback guidance.

Fixes #9

## What changed
- `README.md`
  - Add “Hosted adapter smoke-test (optional)” section.
  - Reminds users to keep secrets in env vars / `.env` and points to `docs/providers.md`.
- `src/triage_assistant/cli.py`
  - Add `doctor` command.
  - Enhance `eval` report output (`Top failure patterns`, `Failure examples`).
  - Preserve strict contract: `triage` prints JSON-only to stdout; errors go to stderr.
- `src/triage_assistant/adapters/*`
  - More actionable HTTP/network errors for GitHub Models / Foundry / OpenAI-compatible.
  - Avoid token/key leakage in errors.
- `tests/*`
  - Add/extend tests for stdout/stderr contract, `doctor`, report headings, and token leak prevention.
- `docs/workshop/*` + `reports/eval/README.md`
  - Add prerequisites/UI drift guardrails.
  - Add evaluation checklist and feedback-loop closure guidance.

## Validation
- `python3 -m pytest -q`

## Notes
- No schema contract changes (`TriageOutput` remains the output contract).
- Hosted adapters remain optional; default offline path continues to work via `dummy`.
