### PR TITLE
Fix: normalize labels strictly

### DIFF
--- a/src/triage_assistant/schema.py
+++ b/src/triage_assistant/schema.py
@@ -58,26 +58,25 @@ class TriageOutput(BaseModel):
         """Normalize labels for stability.
 
         - trims whitespace
+        - lowercases
         - removes empties
-        - de-duplicates case-insensitively while preserving order
+        - de-duplicates while preserving order
         """
-        cleaned: list[str] = []
+        deduped: list[str] = []
+        seen: set[str] = set()
         for label in labels:
             if not isinstance(label, str):
                 continue
-            normalized = label.strip()
+
+            normalized = label.strip().lower()
             if not normalized:
                 continue
-            cleaned.append(normalized)
 
-        deduped: list[str] = []
-        seen: set[str] = set()
-        for label in cleaned:
-            key = label.casefold()
-            if key in seen:
+            if normalized in seen:
                 continue
-            seen.add(key)
-            deduped.append(label)
+
+            seen.add(normalized)
+            deduped.append(normalized)
 
         return deduped
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -13,6 +13,16 @@ def test_labels_normalization_dedup_and_trim() -> None:
     assert out.labels == ["bug", "needs-repro"]
 
 
+def test_labels_normalization_lowercases_first_occurrence() -> None:
+    out = TriageOutput(
+        type=IssueType.bug,
+        priority=Priority.p1,
+        labels=["Needs-Repro", "needs-repro", "P1", "bug"],
+        rationale="Because.",
+    )
+    assert out.labels == ["needs-repro", "p1", "bug"]
+
+
 def test_to_json_roundtrip() -> None:
     out = TriageOutput(
         type=IssueType.feature,


### PR DESCRIPTION
## Summary

Normalize `TriageOutput.labels` for stability:

- trim whitespace
- lowercase
- drop empty labels
- de-duplicate (preserve order)

Add a regression test to ensure the *first* occurrence is also lowercased.

## Related issue

- Fixes #11

## Checklist

- [x] Scoped to a single issue
- [x] Tests added/updated as needed
- [x] `pytest -q` passes
- [x] CLI output contract preserved (JSON on stdout)
- [ ] Docs updated if behavior changed

## Validation

Commands run:

- [x] `pytest -q`
- [x] `ruff check .`
- [x] `ruff format --check .`
